### PR TITLE
Allow the CucumberPro formatter to be enabled without a token.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 require 'cucumber/rake/task'
 Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = ""
-  t.cucumber_opts = "--format Cucumber::Pro --out cucumber-pro.log" if ENV['CUCUMBER_PRO_TOKEN']
+  t.cucumber_opts = "--format Cucumber::Pro --out cucumber-pro.log"
   t.cucumber_opts << "--format pretty"
 end
 

--- a/features/security.feature
+++ b/features/security.feature
@@ -14,14 +14,3 @@ Feature: Security
       | CUCUMBER_PRO_TOKEN | invalid-token |
     And I run `cucumber -f Cucumber::Pro -o /dev/null -f pretty`
     And the stderr should contain "Access denied"
-
-  Scenario: No access token
-    Given a git repo
-    And a feature "features/test.feature" with:
-      """
-      Feature:
-        Scenario:
-          Given passing
-      """
-    When I run `cucumber -f Cucumber::Pro`
-    And the stderr should contain "Missing access token"

--- a/lib/cucumber/pro/errors.rb
+++ b/lib/cucumber/pro/errors.rb
@@ -8,12 +8,6 @@ module Cucumber
         end
       }
 
-      MissingToken = Class.new(StandardError) {
-        def initialize
-          super "Missing access token. Please visit https://app.cucumber.pro/my/profile for instructions."
-        end
-      }
-
       Timeout = Class.new(StandardError) {
         def initialize
           super "Timed out waiting for a reply from the Cucumber Pro server."

--- a/lib/cucumber/pro/formatter.rb
+++ b/lib/cucumber/pro/formatter.rb
@@ -6,8 +6,9 @@ module Cucumber
   module Pro
 
     class Formatter
-      def initialize(session)
+      def initialize(session, working_copy)
         @session = session
+        @working_copy = working_copy
         send_header
       end
 
@@ -53,19 +54,17 @@ module Cucumber
       private
 
       def send_header
-        working_copy = Scm::WorkingCopy.detect
-        working_copy.check_clean
-        @session.send({
-          repo_url: working_copy.repo_url,
-          branch: working_copy.branch,
-          rev: working_copy.rev,
+        @session.send_message({
+          repo_url: @working_copy.repo_url,
+          branch: @working_copy.branch,
+          rev: @working_copy.rev,
           group: get_run_id,
           info: Info.new.to_h
         })
       end
 
       def send_step_result(path, line, status)
-        @session.send({
+        @session.send_message({
           path: path,
           location: line.to_i,
           mime_type: 'application/vnd.cucumber.test-step-result+json',
@@ -74,7 +73,7 @@ module Cucumber
       end
 
       def send_test_case_result(path, line, status)
-        @session.send({
+        @session.send_message({
           path: path,
           location: line.to_i,
           mime_type: 'application/vnd.cucumber-pro.test-case-result+json',

--- a/lib/cucumber/pro/web_socket/session.rb
+++ b/lib/cucumber/pro/web_socket/session.rb
@@ -6,6 +6,13 @@ require 'cucumber/pro/errors'
 module Cucumber
   module Pro
     module WebSocket
+      class NullSession
+        def send_message(message)
+        end
+
+        def close
+        end
+      end
 
       class Session
 
@@ -23,7 +30,7 @@ module Cucumber
           @socket = Worker.new(create_socket, logger, self, options)
         end
 
-        def send(message)
+        def send_message(message)
           logger.debug [:session, :send, message]
           socket.send(message.to_json)
           self


### PR DESCRIPTION
This makes it easier to add the formatter without having to
conditionally enable it. If CUCUMBER_PRO_TOKEN is not defined,
the formatter does not check if the working copy is clean,
and it does not connect to the server. This is how the Cucumber-JVM
implementation works now.

When Cucumber-Ruby is able to read command line options from a
simple file (cucumber.opts), it will be a lot easier to automate
the installation of the formatter.

This fixes #2.
